### PR TITLE
Fix QML state warnings and update imports

### DIFF
--- a/ApplicationFlow.qml
+++ b/ApplicationFlow.qml
@@ -1,210 +1,59 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
+import Backend 1.0
 
 ApplicationFlowForm {
     id: applicationFlow
     state: "Home"
-    property int animationDuration: 400
-    property string platform: Qt.platform.os
-    property string mode: ""
-    property int brewTime
-    property int coffeeAmount
-    property int milkAmount
-    property int foamAmount
-    property double sugarAmount
+    Component.onCompleted: FlowBackend.setRoot(applicationFlow)
 
-    //! [Theme button]
-    function themeButton() {
-        if (Colors.currentTheme == Colors.dark) {
-            Colors.currentTheme = Colors.light
-        } else {
-            Colors.currentTheme = Colors.dark
-        }
-    }
-    //! [Theme button]
-    function cappuccino() {
-        applicationFlow.state = "Settings"
-        applicationFlow.coffeeName = "Cappuccino"
-        coffeeAmount = 60
-        milkAmount = 60
-        foamAmount = 60
-        brewTime = 5000
-        stack.push(settings)
-        coffeeText.text = "Cappuccino"
-    }
-    function espresso() {
-        applicationFlow.state = "Settings"
-        applicationFlow.coffeeName = "Espresso"
-        coffeeAmount = 80
-        milkAmount = 0
-        foamAmount = 0
-        brewTime = 4000
-        stack.push(settings)
-        coffeeText.text = "Espresso"
-    }
-    function latte() {
-        applicationFlow.state = "Settings"
-        applicationFlow.coffeeName = "Latte"
-        coffeeAmount = 40
-        milkAmount = 20
-        foamAmount = 60
-        brewTime = 6000
-        stack.push(settings)
-        coffeeText.text = "Latte"
-    }
-    function macchiato() {
-        applicationFlow.state = "Settings"
-        applicationFlow.coffeeName = "Macchiato"
-        coffeeAmount = 100
-        milkAmount = 5
-        foamAmount = 10
-        brewTime = 8000
-        stack.push(settings)
-        coffeeText.text = "Macchiato"
-    }
-    //! [On clicked]
-    home.getStartedbutton.onClicked: {
-        applicationFlow.state = "Coffee-selection"
-        stack.push(choosingCoffee)
-    }
-    //! [On clicked]
-    function backButton() {
-        stack.pop()
-        applicationFlow.state = applicationFlow.previousState
-    }
-    function confirmButton() {
-        stack.push(insert)
-        applicationFlow.state = "Insert"
-    }
-    function continueButton() {
-        stack.push(progress)
-        applicationFlow.state = "Progress"
-        applicationFlow.progressBarValue = 1
-        applicationFlow.progressCupState = "1"
-        if (applicationFlow.coffeeName == "Cappuccino") {
-            applicationFlow.cappuccinos = applicationFlow.cappuccinos - 1
-        } else if (applicationFlow.coffeeName == "Espresso") {
-            applicationFlow.espressos = applicationFlow.espressos - 1
-        } else if (applicationFlow.coffeeName == "Latte") {
-            applicationFlow.lattes = applicationFlow.lattes - 1
-        } else {
-            applicationFlow.macchiatos = applicationFlow.macchiatos - 1
-        }
-    }
-    function cancelButton() {
-        applicationFlow.state = "Coffee-selection"
-        stack.pop(stack.get(1))
-    }
-    function onFinished() {
-        stack.push(ready)
-        applicationFlow.state = "Ready"
-    }
-    function onReturnToStart() {
-        stack.pop(stack.get(0))
-        applicationFlow.state = "Home"
-        applicationFlow.progressBarValue = 0
-        applicationFlow.progressCupState = "0"
-    }
+    home.getStartedbutton.onClicked: FlowBackend.getStarted()
     //! [States]
     states: [
         State {
             name: "Home"
-            PropertyChanges {
-                target: toolbar
-                backButton.opacity: 0
-                backButton.enabled: false
-                themeButton.opacity: 0
-                themeButton.enabled: false
-                logo.sourceSize.width: 70
-                logo.sourceSize.height: 50
-            }
+            toolbar.backButton.opacity: 0
+            toolbar.backButton.enabled: false
+            toolbar.themeButton.opacity: 0
+            toolbar.themeButton.enabled: false
+            toolbar.logo.sourceSize.width: 70
+            toolbar.logo.sourceSize.height: 50
             //! [States]
-            PropertyChanges {
-                target: coffeeText
-                visible: false
-            }
-            PropertyChanges {
-                target: stack
-                anchors.top: coffeeText.bottom
-            }
+            coffeeText.visible: false
+            stack.anchors.top: coffeeText.bottom
         },
         State {
             name: "Coffee-selection"
-            PropertyChanges {
-                target: applicationFlow
-                previousState: "Home"
-
-            }
-            PropertyChanges {
-                target: coffeeText
-                text: "Coffee Selection"
-            }
-            PropertyChanges {
-                target: toolbar
-                backButton.opacity: 0
-                backButton.enabled: false
-            }
-            PropertyChanges {
-                target: stack
-                anchors.top: coffeeText.bottom
-            }
+            applicationFlow.previousState: "Home"
+            coffeeText.text: "Coffee Selection"
+            toolbar.backButton.opacity: 0
+            toolbar.backButton.enabled: false
+            stack.anchors.top: coffeeText.bottom
         },
         State {
             name: "Settings"
-            PropertyChanges {
-                target: applicationFlow
-                previousState: "Coffee-selection"
-            }
-            PropertyChanges {
-                target: stack
-                anchors.top: coffeeText.bottom
-            }
+            applicationFlow.previousState: "Coffee-selection"
+            stack.anchors.top: coffeeText.bottom
         },
         State {
             name: "Insert"
-            PropertyChanges {
-                target: applicationFlow
-                previousState: "Settings"
-            }
-            PropertyChanges {
-                target: stack
-                anchors.top: coffeeText.bottom
-            }
+            applicationFlow.previousState: "Settings"
+            stack.anchors.top: coffeeText.bottom
         },
         State {
             name: "Progress"
-            PropertyChanges {
-                target: applicationFlow
-                previousState: "Insert"
-
-            }
-            PropertyChanges {
-                target: toolbar
-                backButton.opacity: 0
-                backButton.enabled: false
-            }
-            PropertyChanges {
-                target: stack
-                anchors.top: coffeeText.bottom
-            }
+            applicationFlow.previousState: "Insert"
+            toolbar.backButton.opacity: 0
+            toolbar.backButton.enabled: false
+            stack.anchors.top: coffeeText.bottom
         },
         State {
             name: "Ready"
-            PropertyChanges {
-                target: applicationFlow
-                previousState: "Progress"
-
-            }
-            PropertyChanges {
-                target: toolbar
-                backButton.opacity: 0
-                backButton.enabled: false
-            }
-            PropertyChanges {
-                target: stack
-                anchors.top: coffeeText.bottom
-            }
+            applicationFlow.previousState: "Progress"
+            toolbar.backButton.opacity: 0
+            toolbar.backButton.enabled: false
+            stack.anchors.top: coffeeText.bottom
         }
 
     ]

--- a/ApplicationFlowBackend.cpp
+++ b/ApplicationFlowBackend.cpp
@@ -1,0 +1,294 @@
+#include "ApplicationFlowBackend.h"
+#include <QGuiApplication>
+#include <QMetaObject>
+#include <QVariant>
+#include <QSysInfo>
+
+ApplicationFlowBackend::ApplicationFlowBackend(QObject *parent)
+    : QObject(parent)
+{
+    m_platform = QSysInfo::prettyProductName();
+}
+
+void ApplicationFlowBackend::setAnimationDuration(int value)
+{
+    if (m_animationDuration == value)
+        return;
+    m_animationDuration = value;
+    emit animationDurationChanged();
+}
+
+void ApplicationFlowBackend::setMode(const QString &value)
+{
+    if (m_mode == value)
+        return;
+    m_mode = value;
+    emit modeChanged();
+}
+
+void ApplicationFlowBackend::setBrewTime(int value)
+{
+    if (m_brewTime == value)
+        return;
+    m_brewTime = value;
+    emit brewTimeChanged();
+}
+
+void ApplicationFlowBackend::setCoffeeAmount(int value)
+{
+    if (m_coffeeAmount == value)
+        return;
+    m_coffeeAmount = value;
+    emit coffeeAmountChanged();
+}
+
+void ApplicationFlowBackend::setMilkAmount(int value)
+{
+    if (m_milkAmount == value)
+        return;
+    m_milkAmount = value;
+    emit milkAmountChanged();
+}
+
+void ApplicationFlowBackend::setFoamAmount(int value)
+{
+    if (m_foamAmount == value)
+        return;
+    m_foamAmount = value;
+    emit foamAmountChanged();
+}
+
+void ApplicationFlowBackend::setSugarAmount(double value)
+{
+    if (qFuzzyCompare(m_sugarAmount, value))
+        return;
+    m_sugarAmount = value;
+    emit sugarAmountChanged();
+}
+
+void ApplicationFlowBackend::setDarkTheme(bool value)
+{
+    if (m_darkTheme == value)
+        return;
+    m_darkTheme = value;
+    emit darkThemeChanged();
+}
+
+void ApplicationFlowBackend::setCappuccinos(int value)
+{
+    if (m_cappuccinos == value)
+        return;
+    m_cappuccinos = value;
+    emit cappuccinosChanged();
+}
+
+void ApplicationFlowBackend::setLattes(int value)
+{
+    if (m_lattes == value)
+        return;
+    m_lattes = value;
+    emit lattesChanged();
+}
+
+void ApplicationFlowBackend::setEspressos(int value)
+{
+    if (m_espressos == value)
+        return;
+    m_espressos = value;
+    emit espressosChanged();
+}
+
+void ApplicationFlowBackend::setMacchiatos(int value)
+{
+    if (m_macchiatos == value)
+        return;
+    m_macchiatos = value;
+    emit macchiatosChanged();
+}
+
+void ApplicationFlowBackend::setRoot(QObject *root)
+{
+    m_root = root;
+}
+
+static QObject *find(QObject *root, const char *name)
+{
+    return root ? root->findChild<QObject*>(QString::fromLatin1(name), Qt::FindChildrenRecursively) : nullptr;
+}
+
+void ApplicationFlowBackend::themeButton()
+{
+    setDarkTheme(!m_darkTheme);
+}
+
+void ApplicationFlowBackend::cappuccino()
+{
+    if (!m_root)
+        return;
+    m_root->setProperty("state", "Settings");
+    m_root->setProperty("coffeeName", "Cappuccino");
+    setCoffeeAmount(60);
+    setMilkAmount(60);
+    setFoamAmount(60);
+    setBrewTime(5000);
+    QObject *stack = find(m_root, "stack");
+    QObject *settings = find(m_root, "settings");
+    if (stack && settings)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(settings)));
+    QObject *coffeeText = find(m_root, "coffeeText");
+    if (coffeeText)
+        coffeeText->setProperty("text", "Cappuccino");
+}
+
+void ApplicationFlowBackend::espresso()
+{
+    if (!m_root)
+        return;
+    m_root->setProperty("state", "Settings");
+    m_root->setProperty("coffeeName", "Espresso");
+    setCoffeeAmount(80);
+    setMilkAmount(0);
+    setFoamAmount(0);
+    setBrewTime(4000);
+    QObject *stack = find(m_root, "stack");
+    QObject *settings = find(m_root, "settings");
+    if (stack && settings)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(settings)));
+    QObject *coffeeText = find(m_root, "coffeeText");
+    if (coffeeText)
+        coffeeText->setProperty("text", "Espresso");
+}
+
+void ApplicationFlowBackend::latte()
+{
+    if (!m_root)
+        return;
+    m_root->setProperty("state", "Settings");
+    m_root->setProperty("coffeeName", "Latte");
+    setCoffeeAmount(40);
+    setMilkAmount(20);
+    setFoamAmount(60);
+    setBrewTime(6000);
+    QObject *stack = find(m_root, "stack");
+    QObject *settings = find(m_root, "settings");
+    if (stack && settings)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(settings)));
+    QObject *coffeeText = find(m_root, "coffeeText");
+    if (coffeeText)
+        coffeeText->setProperty("text", "Latte");
+}
+
+void ApplicationFlowBackend::macchiato()
+{
+    if (!m_root)
+        return;
+    m_root->setProperty("state", "Settings");
+    m_root->setProperty("coffeeName", "Macchiato");
+    setCoffeeAmount(100);
+    setMilkAmount(5);
+    setFoamAmount(10);
+    setBrewTime(8000);
+    QObject *stack = find(m_root, "stack");
+    QObject *settings = find(m_root, "settings");
+    if (stack && settings)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(settings)));
+    QObject *coffeeText = find(m_root, "coffeeText");
+    if (coffeeText)
+        coffeeText->setProperty("text", "Macchiato");
+}
+
+void ApplicationFlowBackend::getStarted()
+{
+    if (!m_root)
+        return;
+    m_root->setProperty("state", "Coffee-selection");
+    QObject *stack = find(m_root, "stack");
+    QObject *choosingCoffee = find(m_root, "choosingCoffee");
+    if (stack && choosingCoffee)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(choosingCoffee)));
+}
+
+void ApplicationFlowBackend::backButton()
+{
+    if (!m_root)
+        return;
+    QObject *stack = find(m_root, "stack");
+    if (stack)
+        QMetaObject::invokeMethod(stack, "pop");
+    QString prev = m_root->property("previousState").toString();
+    m_root->setProperty("state", prev);
+}
+
+void ApplicationFlowBackend::confirmButton()
+{
+    if (!m_root)
+        return;
+    QObject *stack = find(m_root, "stack");
+    QObject *insert = find(m_root, "insert");
+    if (stack && insert)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(insert)));
+    m_root->setProperty("state", "Insert");
+}
+
+void ApplicationFlowBackend::continueButton()
+{
+    if (!m_root)
+        return;
+    QObject *stack = find(m_root, "stack");
+    QObject *progress = find(m_root, "progress");
+    if (stack && progress)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(progress)));
+    m_root->setProperty("state", "Progress");
+    m_root->setProperty("progressBarValue", 1);
+    m_root->setProperty("progressCupState", "1");
+    QString coffee = m_root->property("coffeeName").toString();
+    if (coffee == "Cappuccino") {
+        setCappuccinos(m_cappuccinos - 1);
+    } else if (coffee == "Espresso") {
+        setEspressos(m_espressos - 1);
+    } else if (coffee == "Latte") {
+        setLattes(m_lattes - 1);
+    } else {
+        setMacchiatos(m_macchiatos - 1);
+    }
+}
+
+void ApplicationFlowBackend::cancelButton()
+{
+    if (!m_root)
+        return;
+    m_root->setProperty("state", "Coffee-selection");
+    QObject *stack = find(m_root, "stack");
+    if (stack) {
+        QVariant item;
+        QMetaObject::invokeMethod(stack, "get", Q_RETURN_ARG(QVariant, item), Q_ARG(int, 1));
+        QMetaObject::invokeMethod(stack, "pop", Q_ARG(QVariant, item));
+    }
+}
+
+void ApplicationFlowBackend::onFinished()
+{
+    if (!m_root)
+        return;
+    QObject *stack = find(m_root, "stack");
+    QObject *ready = find(m_root, "ready");
+    if (stack && ready)
+        QMetaObject::invokeMethod(stack, "push", Q_ARG(QVariant, QVariant::fromValue(ready)));
+    m_root->setProperty("state", "Ready");
+}
+
+void ApplicationFlowBackend::onReturnToStart()
+{
+    if (!m_root)
+        return;
+    QObject *stack = find(m_root, "stack");
+    if (stack) {
+        QVariant ret;
+        QMetaObject::invokeMethod(stack, "get", Q_RETURN_ARG(QVariant, ret), Q_ARG(int, 0));
+        QMetaObject::invokeMethod(stack, "pop", Q_ARG(QVariant, ret));
+    }
+    m_root->setProperty("state", "Home");
+    m_root->setProperty("progressBarValue", 0);
+    m_root->setProperty("progressCupState", "0");
+}
+

--- a/ApplicationFlowBackend.h
+++ b/ApplicationFlowBackend.h
@@ -1,0 +1,109 @@
+#ifndef APPLICATIONFLOWBACKEND_H
+#define APPLICATIONFLOWBACKEND_H
+
+#include <QObject>
+
+class ApplicationFlowBackend : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(int animationDuration READ animationDuration WRITE setAnimationDuration NOTIFY animationDurationChanged)
+    Q_PROPERTY(QString platform READ platform CONSTANT)
+    Q_PROPERTY(QString mode READ mode WRITE setMode NOTIFY modeChanged)
+    Q_PROPERTY(int brewTime READ brewTime WRITE setBrewTime NOTIFY brewTimeChanged)
+    Q_PROPERTY(int coffeeAmount READ coffeeAmount WRITE setCoffeeAmount NOTIFY coffeeAmountChanged)
+    Q_PROPERTY(int milkAmount READ milkAmount WRITE setMilkAmount NOTIFY milkAmountChanged)
+    Q_PROPERTY(int foamAmount READ foamAmount WRITE setFoamAmount NOTIFY foamAmountChanged)
+    Q_PROPERTY(double sugarAmount READ sugarAmount WRITE setSugarAmount NOTIFY sugarAmountChanged)
+    Q_PROPERTY(bool darkTheme READ darkTheme WRITE setDarkTheme NOTIFY darkThemeChanged)
+    Q_PROPERTY(int cappuccinos READ cappuccinos WRITE setCappuccinos NOTIFY cappuccinosChanged)
+    Q_PROPERTY(int lattes READ lattes WRITE setLattes NOTIFY lattesChanged)
+    Q_PROPERTY(int espressos READ espressos WRITE setEspressos NOTIFY espressosChanged)
+    Q_PROPERTY(int macchiatos READ macchiatos WRITE setMacchiatos NOTIFY macchiatosChanged)
+
+public:
+    explicit ApplicationFlowBackend(QObject *parent = nullptr);
+
+    int animationDuration() const { return m_animationDuration; }
+    void setAnimationDuration(int value);
+
+    QString platform() const { return m_platform; }
+
+    QString mode() const { return m_mode; }
+    void setMode(const QString &value);
+
+    int brewTime() const { return m_brewTime; }
+    void setBrewTime(int value);
+
+    int coffeeAmount() const { return m_coffeeAmount; }
+    void setCoffeeAmount(int value);
+
+    int milkAmount() const { return m_milkAmount; }
+    void setMilkAmount(int value);
+
+    int foamAmount() const { return m_foamAmount; }
+    void setFoamAmount(int value);
+
+    double sugarAmount() const { return m_sugarAmount; }
+    void setSugarAmount(double value);
+
+    bool darkTheme() const { return m_darkTheme; }
+    void setDarkTheme(bool value);
+
+    int cappuccinos() const { return m_cappuccinos; }
+    void setCappuccinos(int value);
+
+    int lattes() const { return m_lattes; }
+    void setLattes(int value);
+
+    int espressos() const { return m_espressos; }
+    void setEspressos(int value);
+
+    int macchiatos() const { return m_macchiatos; }
+    void setMacchiatos(int value);
+
+    Q_INVOKABLE void setRoot(QObject *root);
+    Q_INVOKABLE void themeButton();
+    Q_INVOKABLE void cappuccino();
+    Q_INVOKABLE void espresso();
+    Q_INVOKABLE void latte();
+    Q_INVOKABLE void macchiato();
+    Q_INVOKABLE void getStarted();
+    Q_INVOKABLE void backButton();
+    Q_INVOKABLE void confirmButton();
+    Q_INVOKABLE void continueButton();
+    Q_INVOKABLE void cancelButton();
+    Q_INVOKABLE void onFinished();
+    Q_INVOKABLE void onReturnToStart();
+
+signals:
+    void animationDurationChanged();
+    void modeChanged();
+    void brewTimeChanged();
+    void coffeeAmountChanged();
+    void milkAmountChanged();
+    void foamAmountChanged();
+    void sugarAmountChanged();
+    void darkThemeChanged();
+    void cappuccinosChanged();
+    void lattesChanged();
+    void espressosChanged();
+    void macchiatosChanged();
+
+private:
+    QObject *m_root = nullptr;
+    int m_animationDuration = 400;
+    QString m_platform;
+    QString m_mode;
+    int m_brewTime = 0;
+    int m_coffeeAmount = 0;
+    int m_milkAmount = 0;
+    int m_foamAmount = 0;
+    double m_sugarAmount = 0.0;
+    bool m_darkTheme = true;
+    int m_cappuccinos = 4;
+    int m_lattes = 5;
+    int m_espressos = 6;
+    int m_macchiatos = 4;
+};
+
+#endif // APPLICATIONFLOWBACKEND_H

--- a/ApplicationFlowForm.ui.qml
+++ b/ApplicationFlowForm.ui.qml
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
 import QtQuick.Controls.Basic
+import Backend 1.0
 
 Rectangle {
     // Height, width and any other size related properties containing odd looking float or other dividers
@@ -56,7 +57,7 @@ Rectangle {
         initialItem: Home {
             id: home
             visible: true
-            state: applicationFlow.mode
+            state: FlowBackend.mode
         }
         pushEnter: Transition {
             PropertyAnimation {
@@ -96,33 +97,33 @@ Rectangle {
         id: choosingCoffee
         ChoosingCoffee {
             visible: true
-            state: applicationFlow.mode
+            state: FlowBackend.mode
         }
     }
     Component {
         id: settings
         Settings {
-            foamAmount: applicationFlow.foamAmount
-            milkAmount: applicationFlow.milkAmount
-            coffeeAmount: applicationFlow.coffeeAmount
-            state: applicationFlow.mode
+            foamAmount: FlowBackend.foamAmount
+            milkAmount: FlowBackend.milkAmount
+            coffeeAmount: FlowBackend.coffeeAmount
+            state: FlowBackend.mode
         }
     }
     Component {
         id: insert
         Insert {
-            state: applicationFlow.mode
+            state: FlowBackend.mode
         }
     }
     Component {
         id: progress
         Progress {
-            brewTime: applicationFlow.brewTime
-            coffeeAmount: applicationFlow.coffeeAmount
-            milkAmount: applicationFlow.milkAmount
-            foamAmount: applicationFlow.foamAmount
-            sugarAmount: applicationFlow.sugarAmount
-            state: applicationFlow.mode
+            brewTime: FlowBackend.brewTime
+            coffeeAmount: FlowBackend.coffeeAmount
+            milkAmount: FlowBackend.milkAmount
+            foamAmount: FlowBackend.foamAmount
+            sugarAmount: FlowBackend.sugarAmount
+            state: FlowBackend.mode
             progressBarValue: root.progressBarValue
             cup.state: root.progressCupState
         }
@@ -130,11 +131,11 @@ Rectangle {
     Component {
         id: ready
         Ready {
-            foamAmount: applicationFlow.foamAmount
-            milkAmount: applicationFlow.milkAmount
-            coffeeAmount: applicationFlow.coffeeAmount
-            sugarAmount: applicationFlow.sugarAmount
-            state: applicationFlow.mode
+            foamAmount: FlowBackend.foamAmount
+            milkAmount: FlowBackend.milkAmount
+            coffeeAmount: FlowBackend.coffeeAmount
+            sugarAmount: FlowBackend.sugarAmount
+            state: FlowBackend.mode
         }
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ qt_standard_project_setup(REQUIRES 6.6)
 
 qt_add_executable(coffeemachine
     main.cpp
+    ApplicationFlowBackend.cpp
 )
 
 set_source_files_properties(Colors.qml PROPERTIES

--- a/ChoosingCoffee.qml
+++ b/ChoosingCoffee.qml
@@ -1,9 +1,11 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 
+import Backend 1.0
+
 ChoosingCoffeeForm {
-    cappuccino.button.onClicked: applicationFlow.cappuccino()
-    macchiato.button.onClicked: applicationFlow.macchiato()
-    espresso.button.onClicked: applicationFlow.espresso()
-    latte.button.onClicked: applicationFlow.latte()
+    cappuccino.button.onClicked: FlowBackend.cappuccino()
+    macchiato.button.onClicked: FlowBackend.macchiato()
+    espresso.button.onClicked: FlowBackend.espresso()
+    latte.button.onClicked: FlowBackend.latte()
 }

--- a/ChoosingCoffeeForm.ui.qml
+++ b/ChoosingCoffeeForm.ui.qml
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
 import QtQuick.Layouts
+import Backend 1.0
 
 Item {
     // Height, width and any other size related properties containing odd looking float or other dividers
@@ -48,28 +49,28 @@ Item {
             coffeeName: "Cappuccino"
             ingredients: "Milk, Espresso, Foam"
             time: 2
-            cupsLeft: applicationFlow.cappuccinos
+            cupsLeft: FlowBackend.cappuccinos
         }
         CoffeeCard {
             id: latte
             coffeeName: "Latte"
             ingredients: "Coffee, Foam"
             time: 3
-            cupsLeft: applicationFlow.lattes
+            cupsLeft: FlowBackend.lattes
         }
         CoffeeCard {
             id: espresso
             coffeeName: "Espresso"
             ingredients: "Milk, Espresso"
             time: 2
-            cupsLeft: applicationFlow.espressos
+            cupsLeft: FlowBackend.espressos
         }
         CoffeeCard {
             id: macchiato
             coffeeName: "Macchiato"
             ingredients: "Milk foam, Espresso"
             time: 4
-            cupsLeft: applicationFlow.macchiatos
+            cupsLeft: FlowBackend.macchiatos
         }
     }
     //! [Coffees]

--- a/CoffeeCard.qml
+++ b/CoffeeCard.qml
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
 import QtQuick.Layouts
+import Backend 1.0
 
 CoffeeCardForm {
 
@@ -72,7 +73,7 @@ CoffeeCardForm {
         },
         State {
             name: "smaller"
-            when: applicationFlow.mode == "portrait" && ((Screen.height * Screen.devicePixelRatio) + (Screen.width * Screen.devicePixelRatio)) < 1200
+            when: FlowBackend.mode == "portrait" && ((Screen.height * Screen.devicePixelRatio) + (Screen.width * Screen.devicePixelRatio)) < 1200
             PropertyChanges {
                 target: coffeeCardCircle
                 implicitWidth: coffeeCardRectangle.implicitWidth / 2

--- a/CoffeeCardForm.ui.qml
+++ b/CoffeeCardForm.ui.qml
@@ -4,6 +4,7 @@ import QtQuick
 import QtQuick.Layouts
 import QtQuick.Controls.Basic
 import QtQuick.Effects
+import Backend 1.0
 
 // Height, width and any other size related properties containing odd looking float or other dividers
 // that do not seem to have any logical origin are just arbitrary and based on original design
@@ -30,7 +31,7 @@ Column {
     states: [
         State {
             name: "portrait"
-            when: applicationFlow.mode == "portrait"
+            when: FlowBackend.mode == "portrait"
             PropertyChanges {
                 target: coffeeCardRectangle
                 implicitHeight: (applicationFlow.stack.height / 2) - 20
@@ -40,7 +41,7 @@ Column {
         },
         State {
             name: "landscape"
-            when: applicationFlow.mode == "landscape"
+            when: FlowBackend.mode == "landscape"
             PropertyChanges {
                 target: coffeeCardRectangle
                 implicitHeight: applicationFlow.height / 2

--- a/Colors.qml
+++ b/Colors.qml
@@ -3,6 +3,7 @@
 
 pragma Singleton
 import QtQuick
+import Backend 1.0
 
 Item {
     QtObject {
@@ -120,7 +121,7 @@ Item {
     property color shadow: "white"
     property color border: "#898989"
     property color grey: "#585858"
-    property var currentTheme: dark
+    property var currentTheme: FlowBackend.darkTheme ? dark : light
     property alias dark: dark
     property alias light: light
     property alias invertedGreenBorder: invertedGreenBorder

--- a/CustomToolBar.qml
+++ b/CustomToolBar.qml
@@ -1,10 +1,11 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
+import Backend 1.0
 
 CustomToolBarForm {
-    backButton.onClicked: applicationFlow.backButton()
-    themeButton.onClicked: applicationFlow.themeButton()
+    backButton.onClicked: FlowBackend.backButton()
+    themeButton.onClicked: FlowBackend.themeButton()
     backButton.states: State {
         name: "pressed"
         when: backButton.pressed

--- a/Insert.qml
+++ b/Insert.qml
@@ -1,7 +1,9 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 
+import Backend 1.0
+
 InsertForm {
-    continueButton.onClicked: applicationFlow.continueButton()
-    cancelButton.onClicked: applicationFlow.cancelButton()
+    continueButton.onClicked: FlowBackend.continueButton()
+    cancelButton.onClicked: FlowBackend.cancelButton()
 }

--- a/Progress.qml
+++ b/Progress.qml
@@ -1,6 +1,7 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
+import Backend 1.0
 
 ProgressForm {
     property alias timer: timer
@@ -13,7 +14,7 @@ ProgressForm {
         interval: brewTime
         running: true
         onTriggered: {
-            applicationFlow.onFinished()
+            FlowBackend.onFinished()
         }
     }
     //! [Timer]

--- a/Ready.qml
+++ b/Ready.qml
@@ -1,6 +1,7 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
+import Backend 1.0
 
 ReadyForm {
     property alias timer: timer
@@ -10,7 +11,7 @@ ReadyForm {
         interval: 3000
         running: true
         onTriggered: {
-            applicationFlow.onReturnToStart()
+            FlowBackend.onReturnToStart()
         }
     }
     grid.states: [

--- a/Settings.qml
+++ b/Settings.qml
@@ -1,6 +1,7 @@
 // Copyright (C) 2023 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
+import Backend 1.0
 
 SettingsForm {
     rectangle.states: [
@@ -60,19 +61,19 @@ SettingsForm {
     sugarSlider.onMoved: {
         sugarText.sugarAmount = sugarSlider.position * 4
     }
-    confirmButton.onClicked: applicationFlow.confirmButton()
+    confirmButton.onClicked: FlowBackend.confirmButton()
     //! [Value changed]
     coffeeSlider.onValueChanged: {
-        applicationFlow.coffeeAmount = coffeeSlider.value
+        FlowBackend.coffeeAmount = coffeeSlider.value
     }
     //! [Value changed]
     milkSlider.onValueChanged: {
-        applicationFlow.milkAmount = milkSlider.value
+        FlowBackend.milkAmount = milkSlider.value
     }
     foamSlider.onValueChanged: {
-        applicationFlow.foamAmount = foamSlider.value
+        FlowBackend.foamAmount = foamSlider.value
     }
     sugarSlider.onValueChanged: {
-        applicationFlow.sugarAmount = sugarSlider.value
+        FlowBackend.sugarAmount = sugarSlider.value
     }
 }

--- a/main.cpp
+++ b/main.cpp
@@ -3,10 +3,15 @@
 
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QtQml>
+#include "ApplicationFlowBackend.h"
 
 int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
+
+    static ApplicationFlowBackend backend;
+    qmlRegisterSingletonInstance<ApplicationFlowBackend>("Backend", 1, 0, "FlowBackend", &backend);
 
     QQmlApplicationEngine engine;
     engine.load(QUrl(QLatin1String("qrc:/qt/qml/demos/coffee/main.qml")));

--- a/main.qml
+++ b/main.qml
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 import QtQuick
 import QtQuick.Controls.Basic
+import Backend 1.0
 //! [Set application window size]
 ApplicationWindow {
     visible: true
@@ -12,6 +13,8 @@ ApplicationWindow {
     ApplicationFlow {
         width: parent.width
         height: parent.height
-        mode: (Screen.height > Screen.width) ? "portrait" : "landscape"
+    }
+    Component.onCompleted: {
+        FlowBackend.mode = (Screen.height > Screen.width) ? "portrait" : "landscape"
     }
 }


### PR DESCRIPTION
## Summary
- silence QML state warnings by using direct property assignments
- add version to Backend imports for all QML files

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6)*